### PR TITLE
mutex for ipbase (geo ip) info to reduce request number to it

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run linter
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.47.0
   unit-tests:


### PR DESCRIPTION
```
        // ipbase api free plan contains only 150 calls
	// the frontend client makes 3 concurrent requests upon home page opened: /whereami, weather current,
	// and weather forecast (5 days); all these result in 3 concurrent (and unnecessary) requests to
	// my poor ipbase free plan, thus a mutex is required here to reduce this number, and try getting
	// cached ip info value from redis
```