### PR TITLE
github.com/honeycombio/otel-config-go v1.13.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/honeycombio/honeycomb-opentelemetry-go v0.10.0
-	github.com/honeycombio/otel-config-go v1.14.0
+	github.com/honeycombio/otel-config-go v1.13.1
 	github.com/ipinfo/go/v2 v2.10.0
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0Q
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/honeycombio/honeycomb-opentelemetry-go v0.10.0 h1:VEfkR+WP35D2H7PbeUqZtfmbUuKjnv39CdQLgR7TfTY=
 github.com/honeycombio/honeycomb-opentelemetry-go v0.10.0/go.mod h1:3AcXbJMBChalA+cgGqGn/tKF/Ce5pW5bZtnci60GqJo=
-github.com/honeycombio/otel-config-go v1.14.0 h1:Na1ERKYXKrnviORrFF3csdcIJhMVHu1kKUZwhhWMLjs=
-github.com/honeycombio/otel-config-go v1.14.0/go.mod h1:Wm3qyqj1Rc9mkSdRxVxhsWdlqOIMNi/46l5/bZEojb4=
+github.com/honeycombio/otel-config-go v1.13.1 h1:JYERH81ChVB4vH3Jmo8ifAkeKhVRD85uaaLLpm4MzY0=
+github.com/honeycombio/otel-config-go v1.13.1/go.mod h1:5hRpKBVO2cMXBaonDmr6KHYB2N/Q5AD3hr7+PVJQOx0=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ipinfo/go/v2 v2.10.0 h1:v9sFjaxnVVD+JVgpWpjgwols18Tuu4SgBDaHHaw0IXo=

--- a/internal/gymstats/exercises/exercises_repo.go
+++ b/internal/gymstats/exercises/exercises_repo.go
@@ -183,8 +183,6 @@ func (r *Repo) ListAll(ctx context.Context, params ExerciseParams) (_ []Exercise
 		span.SetAttributes(attribute.String("to", params.To.String()))
 	}
 
-	log.Tracef("getting all exercises: %+v", params)
-
 	rows, err := r.db.Query(
 		ctx,
 		`

--- a/internal/telemetry/tracing/tracing.go
+++ b/internal/telemetry/tracing/tracing.go
@@ -46,7 +46,7 @@ func HoneycombSetup(
 		otelconfig.WithLogLevel("info"), // info log is default anyway
 	)
 	if err != nil {
-		return nil, fmt.Errorf("honecomb, configure open telemetry: %w", err)
+		return nil, fmt.Errorf("honeycomb, configure open telemetry: %w", err)
 	}
 
 	return shutdownFunc, err


### PR DESCRIPTION
Fix for:
`
time="2024-03-24T21:43:25+01:00" level=fatal msg="new server: honecomb, configure open telemetry: 1 errors occurred detecting resource:\n\t* conflicting Schema URL: https://opentelemetry.io/schemas/1.21.0 and https://opentelemetry.io/schemas/1.24.0"
`
Coming probably from: https://github.com/honeycombio/otel-config-go